### PR TITLE
Fazendo a ligação do banco de dados MySQL

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,7 @@ dependencies {
     compileOnly "io.micronaut:micronaut-inject-groovy"
     console "org.grails:grails-console"
     profile "org.grails.profiles:web"
+    runtime "mysql:mysql-connector-java:8.0.23"
     runtime "org.glassfish.web:el-impl:2.1.2-b03"
     runtime "com.h2database:h2"
     runtime "org.apache.tomcat:tomcat-jdbc"

--- a/grails-app/conf/application.yml
+++ b/grails-app/conf/application.yml
@@ -107,8 +107,18 @@ dataSource:
 environments:
     development:
         dataSource:
-            dbCreate: create-drop
-            url: jdbc:h2:mem:devDb;MVCC=TRUE;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE
+            dbCreate: "update"
+            url: "jdbc:mysql://localhost/desafio"
+            driverClassName: "com.mysql.cj.jdbc.Driver"
+            username: "root"
+            password: "basedeelite"
+            type: "com.zaxxer.hikari.HikariDataSource"
+            properties:
+                connectionTimeout: 30000
+                idleTimeout: 600000
+                maxLifetime: 1800000
+                connectionTestQuery: "SELECT 1"
+                maximumPoolSize: 5
     test:
         dataSource:
             dbCreate: update


### PR DESCRIPTION
### Impacto
Foi adicionado as configurações do gradle e yml para conectar o projeto com o banco de dados MySQL para quando cadastrar um customer, payer ou payment, os dados do mesmo ficarem registrados e salvos no nosso banco de dados MySQL. 

### PR Predecessora
Não possui PR predecessora

### Link da tarefa no JIRA / Trello
https://asaasdev.atlassian.net/browse/STAGS-33?atlOrigin=eyJpIjoiMDAwYzExNTI4MTZlNDBlN2I2ZDE4NTUwMzM0MjcyZWUiLCJwIjoiaiJ9

### Prints do desenvolvimento
![11](https://user-images.githubusercontent.com/101341760/173133137-123f9366-ec0e-4935-9fd0-c00ca43a4e6e.png)

